### PR TITLE
Truncate thread's body on home page.

### DIFF
--- a/resources/views/forum/index.blade.php
+++ b/resources/views/forum/index.blade.php
@@ -39,7 +39,7 @@
 						<hr>
 						<div class="row">
 							<div class="col-12">
-								<p class='thread-body'>{!! str_limit($t->body,400, '...') !!}</p>
+								<p class='thread-body'>{!! str_limit($t->body,400, '...</div>') !!}</p>
 							</div>
 						</div>
 						<div class="row">

--- a/resources/views/forum/index.blade.php
+++ b/resources/views/forum/index.blade.php
@@ -39,7 +39,7 @@
 						<hr>
 						<div class="row">
 							<div class="col-12">
-								<p class='thread-body'>{!!$t->body!!}</p>
+								<p class='thread-body'>{!! str_limit($t->body,400, '...') !!}</p>
 							</div>
 						</div>
 						<div class="row">


### PR DESCRIPTION
To show only the first 400 characters and followed by '...'
as asked in the issue #10 
Threads will not take up too much space on the home page now.

Closes: #10 